### PR TITLE
add __main__.py to project

### DIFF
--- a/dbl_archive_data_storage/__main__.py
+++ b/dbl_archive_data_storage/__main__.py
@@ -1,0 +1,9 @@
+"""
+This is the entry point for the package when run as a package.
+
+Ideally, this module will parse command line options and arguments and do some
+meaningful work (TBD).
+"""
+
+# TODO: spec this out and implement it.
+print("hello world!")


### PR DESCRIPTION
This is place-holder code for when we have time and a better sense of requirements.

__main__.py is a magic module in the sense that if it exists, it is used when the module is called as a script (i.e. `python -m my_package`). If/when we write a controlling script for the package, we should delegate to the __main__.py file.

This isn't meant to be the completion of this issue, just a milestone.